### PR TITLE
chore: moving from docker run to services to prevent a requirement of a docker daemon being used.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -78,7 +78,7 @@ jobs:
           go-version: "1.26.2"
       - run: make test-integration
         env:
-          S3_ENDPOINT: http://minio:9000
+          S3_ENDPOINT: http://localhost:9000
 
   generate-check:
     name: Generated code check

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -57,30 +57,27 @@ jobs:
           name: gosec-sarif
           path: gosec-results.sarif
           if-no-files-found: ignore
-
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
     needs: [lint, test]
+    services:
+      minio:
+        image: quay.io/minio/minio:latest
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        options: --health-cmd "curl -f http://localhost:9000/minio/health/live || exit 1" --health-interval 5s --health-timeout 3s --health-retries 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # 6.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
         with:
           go-version: "1.26.2"
-      - name: Start MinIO
-        run: |
-          docker run -d --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            quay.io/minio/minio:latest server /data
-          for i in $(seq 1 30); do
-            curl -sS http://localhost:9000/minio/health/live && break
-            sleep 1
-          done
       - run: make test-integration
         env:
-          S3_ENDPOINT: http://localhost:9000
+          S3_ENDPOINT: http://minio:9000
 
   generate-check:
     name: Generated code check

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -64,6 +64,7 @@ jobs:
     services:
       minio:
         image: quay.io/minio/minio:latest
+        command: server /data
         ports:
           - 9000:9000
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-04-10
+
+### :gear: Changed
+- Moving from docker run to services to prevent a requirement of a docker daemon being used.
+
+
 ## [1.2.1] - 2026-04-10
 
 ### :gear: Changed
@@ -120,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## New Contributors
 * @drew-viles made their first contribution in [#1](https://github.com/drewbernetes/simple-s3/pull/1)
+[1.2.2]: https://github.com/drewbernetes/simple-s3/compare/v1.2.1..v1.2.2
 [1.2.1]: https://github.com/drewbernetes/simple-s3/compare/v1.2.0..v1.2.1
 [1.2.0]: https://github.com/drewbernetes/simple-s3/compare/v1.1.0..v1.2.0
 [1.1.0]: https://github.com/drewbernetes/simple-s3/compare/v1.0.0..v1.1.0


### PR DESCRIPTION
This is required because if this runs on a GH-ARC runner for example that is hosted on k8s, it's translated into a pod instead of requiring the running of DIND.
